### PR TITLE
RAND-200 - Correctly alias ALB in route53 record and non-internal ALB

### DIFF
--- a/groups/infrastructure/alb.tf
+++ b/groups/infrastructure/alb.tf
@@ -6,6 +6,7 @@ module "alb" {
   ssl_certificate_arn = aws_acm_certificate.certificate.arn
   subnet_ids          = data.aws_subnets.public.ids
   vpc_id              = data.aws_vpc.vpc.id
+  internal            = false
 
   create_security_group = true
 

--- a/groups/infrastructure/route-53.tf
+++ b/groups/infrastructure/route-53.tf
@@ -38,6 +38,12 @@ resource "aws_route53_record" "a_record" {
   name            = local.domain_name
   type            = "A"
   zone_id         = data.aws_route53_zone.hosted_zone.id
-  records         = [module.alb.application_load_balancer_dns_name]
-  ttl             = 60
+
+  alias {
+    name                   = module.alb.application_load_balancer_dns_name
+    zone_id                = module.alb.application_load_balancer_zone_id
+    evaluate_target_health = false
+  }
+
+  ttl = 60
 }


### PR DESCRIPTION
Adds alias record as per: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record#alias-record - to resolve:

```txt
╷
│ Error: creating Route 53 Record: InvalidChangeBatch: [Invalid Resource Record: 'FATAL problem: ARRDATAIllegalIPv4Address (Value is not a valid IPv4 address) encountered with 'internal-alb-randd-rand-229418441.eu-west-2.elb.amazonaws.com'']
│ 	status code: 400, request id: 4e5d5aa1-95a3-47bc-bed0-8b74cb134a80
│ 
│   with aws_route53_record.a_record,
│   on route-53.tf line 36, in resource "aws_route53_record" "a_record":
│   36: resource "aws_route53_record" "a_record" {
│ 
```